### PR TITLE
Fix failing GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,13 @@ on: [push]
 jobs: 
   build_and_deploy:
     runs-on: ubuntu-latest
+    name: Build & Deploy to GitHub Pages
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v1
-      - name: Build & Deploy to GitHub Pages
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-          GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
-          BASE_URL: /2024
-        uses: MarkBind/markbind-action@1.0.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm i -g markbind-cli
+      - run: markbind deploy --ci


### PR DESCRIPTION
This updates the workflow to use [the current sample GitHub Actions workflow on the MarkBind user guide](https://markbind.org/userGuide/deployingTheSite.html#deploying-via-github-actions).

It was failing due to the nullish coalescing operator used in the following code introduced in a recent MarkBind pull request MarkBind/markbind#2395.

![image](https://github.com/nus-cs3281/2024/assets/65202977/d56761eb-3de0-44d6-989a-3353c6cf7719)

The nullish coalescing operator was introduced in Node.js v14, but [the current workflow uses Node.js v10](https://github.com/MarkBind/markbind-action/blob/1.0.0/Dockerfile).

![image](https://github.com/nus-cs3281/2024/assets/65202977/d72c7bb9-c798-4931-9677-bb71114bd835)